### PR TITLE
チームを削除するデバッグ操作を追加

### DIFF
--- a/src/components/pages/Team/Team.module.scss
+++ b/src/components/pages/Team/Team.module.scss
@@ -14,6 +14,11 @@
   margin: rem(24) rem(24) auto;
 }
 
+.body {
+  padding: 0 rem(24);
+  margin: rem(48) 0 0;
+}
+
 // リスト
 .list {
   display: flex;

--- a/src/components/pages/Team/Team.tsx
+++ b/src/components/pages/Team/Team.tsx
@@ -8,6 +8,7 @@ import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
 import { useGetTeamListQuery } from 'store/team';
 import { useAddMemberMutation, updateTeam } from 'store/team';
+import { useRemoveTeamMutation } from 'store/team';
 
 import styles from './Team.module.scss';
 
@@ -52,6 +53,15 @@ export const Team: FC = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [entriesAddSuccess]);
 
+  // デバッグ用: チームの削除
+  const [sendRemoveTeamMutation] = useRemoveTeamMutation();
+  const handleRemoveTeam = useCallback(() => {
+    if (window.confirm('Are you sure you want to delete this team?')) {
+      sendRemoveTeamMutation(selectedTeam || '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedTeam]);
+
   return (
     <>
       <article className={styles.team}>
@@ -74,6 +84,14 @@ export const Team: FC = () => {
             ))}
           </ul>
           <AddListItem addClass={[styles.addForm]} />
+          <div className={styles.body}>
+            <Button
+              handleClick={handleRemoveTeam}
+              disabled={!getTeamSuccess || entriesAddLoading || !selectedTeam || !localId}
+            >
+              (debug) delete team
+            </Button>
+          </div>
         </div>
         <footer className={styles.footer}>
           <Button

--- a/src/components/pages/Team/components/AddListItem/AddListItem.tsx
+++ b/src/components/pages/Team/components/AddListItem/AddListItem.tsx
@@ -37,7 +37,13 @@ export const AddListItem: FC<AddListItemProps> = ({ addClass = [], callback }) =
         placeholder="Your team not on the list?"
         className={styles.input}
       />
-      <Button handleClick={testAddTeam} disabled={teamAddLoading || !newTeamName.length}>
+      <Button
+        handleClick={() => {
+          testAddTeam();
+          setNewTeamName('');
+        }}
+        disabled={teamAddLoading || !newTeamName.length}
+      >
         add
       </Button>
     </div>

--- a/src/components/pages/WaitingRoom/components/CurrentMembers/CurrentMembers.module.scss
+++ b/src/components/pages/WaitingRoom/components/CurrentMembers/CurrentMembers.module.scss
@@ -31,7 +31,7 @@
   font-size: rem(12);
 }
 
-.winner {
+.job {
   position: absolute;
   bottom: 100%;
   margin: rem(6) 0;

--- a/src/components/pages/WaitingRoom/components/CurrentMembers/CurrentMembers.tsx
+++ b/src/components/pages/WaitingRoom/components/CurrentMembers/CurrentMembers.tsx
@@ -19,7 +19,7 @@ export const CurrentMembers: FC<CurrentMembersProps> = ({
     <div className={[styles.memberList, ...addClass].join(' ')}>
       {memberList.map(item => (
         <div key={item} className={styles.member}>
-          {item === challenger && <span className={styles.winner}>challenger</span>}
+          <span className={styles.job}>{item === challenger ? 'Rescuer' : 'Charger'}</span>
           <span className={styles.memberIcon} style={{ color: `#${item}` }}></span>
           {item === myself && <span className={styles.current}>myself</span>}
         </div>


### PR DESCRIPTION
- 抜けられないメンバーが残った時の対策としてチームを丸ごと削除するボタンを設置

ついで修正

- チームを追加したときテキストボックスをリセット
- 役割抽選後、全員に役職名を表示