### PR TITLE
レイアウト修正

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "UNLICENSED",
       "dependencies": {
+        "@headlessui/react": "^1.7.17",
         "firebase": "^10.3.1",
         "html-react-parser": "^3.0.1",
         "modern-css-reset": "^1.4.0",
@@ -16,6 +17,7 @@
         "postcss-syntax": "^0.36.2",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
+        "react-icons": "^4.11.0",
         "react-redux": "^8.0.5",
         "react-router-dom": "^6.8.0",
         "react-scripts": "^5.0.1",
@@ -59,8 +61,7 @@
         "stylelint-config-recess-order": "^3.0.0",
         "stylelint-config-standard": "^25.0.0",
         "tsconfig-paths-webpack-plugin": "^3.5.2",
-        "typescript": "^4.7.3",
-        "web-vitals": "^2.1.4"
+        "typescript": "^4.7.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3110,6 +3111,21 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.17",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.17.tgz",
+      "integrity": "sha512-4am+tzvkqDSSgiwrsEpGWqgGo9dz8qU5M3znCkC4PgkpY4HcCZzEDEvozltGGGHIKl9jbXbZPSH5TWn4sWJdow==",
+      "dependencies": {
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -16015,6 +16031,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA=="
     },
     "node_modules/cliui": {
       "version": "8.0.1",
@@ -32513,6 +32534,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.11.tgz",
       "integrity": "sha512-/6UZ2qgEyH2aqzYZgQPxEnz33NJ2gNsnHA2o5+o4wW9bLM/JYQitNP9xPhsXwC08hMMovfGe/8retsdDsczPRg=="
     },
+    "node_modules/react-icons": {
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-4.11.0.tgz",
+      "integrity": "sha512-V+4khzYcE5EBk/BvcuYRq6V/osf11ODUM2J8hg2FDSswRrGvqiYUYPRy4OdrWaQOBj4NcpJfmHZLNaD+VH0TyA==",
+      "peerDependencies": {
+        "react": "*"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -38366,8 +38395,7 @@
     "node_modules/web-vitals": {
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-2.1.4.tgz",
-      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg==",
-      "dev": true
+      "integrity": "sha512-sVWcwhU5mX6crfI5Vd2dC4qchyTqxV8URinzt25XqVh+bHEPGH4C3NPrNionCP7Obx59wrYEbNlw4Z8sjALzZg=="
     },
     "node_modules/webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "last 2 versions"
   ],
   "dependencies": {
+    "@headlessui/react": "^1.7.17",
     "firebase": "^10.3.1",
     "html-react-parser": "^3.0.1",
     "modern-css-reset": "^1.4.0",
@@ -39,6 +40,7 @@
     "postcss-syntax": "^0.36.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-icons": "^4.11.0",
     "react-redux": "^8.0.5",
     "react-router-dom": "^6.8.0",
     "react-scripts": "^5.0.1",

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -6,12 +6,12 @@ import { Outlet } from 'react-router-dom';
 
 import { RootState } from 'store';
 import {
+  updateTeam,
   useGetPlayerQuery,
   useGetTeamArticleQuery,
   useAddPlayerMutation,
   updateLocalId,
 } from 'store/player';
-import { useGetTeamListQuery, updateTeam } from 'store/team';
 
 import { useGenerateAndStoreSessionId } from 'hooks/useGenerateAndStoreSessionId';
 
@@ -23,8 +23,7 @@ export const Layout: FC = () => {
   // ID生成
   const generateId = useGenerateAndStoreSessionId;
 
-  const { playerList } = useSelector((state: RootState) => state.player);
-  const { selectedTeam } = useSelector((state: RootState) => state.team);
+  const { playerList, selectedTeam } = useSelector((state: RootState) => state.player);
 
   // 既存のプレイヤー情報取得
   const { isSuccess: getPlayerSuccess } = useGetPlayerQuery();

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -17,6 +17,8 @@ import { useGenerateAndStoreSessionId } from 'hooks/useGenerateAndStoreSessionId
 
 import styles from './Layout.module.scss';
 
+import { LayoutHeader } from './components/LayoutHeader';
+
 export const Layout: FC = () => {
   const dispatch = useDispatch();
 
@@ -110,6 +112,7 @@ export const Layout: FC = () => {
 export const LayoutView: FC = () => {
   return (
     <div className={[styles.layout].join(' ')}>
+      <LayoutHeader />
       <Outlet />
     </div>
   );

--- a/src/components/layout/Layout/Layout.tsx
+++ b/src/components/layout/Layout/Layout.tsx
@@ -5,7 +5,12 @@ import { useDispatch, useSelector } from 'react-redux';
 import { Outlet } from 'react-router-dom';
 
 import { RootState } from 'store';
-import { useGetPlayerQuery, useAddPlayerMutation, updateLocalId } from 'store/player';
+import {
+  useGetPlayerQuery,
+  useGetTeamArticleQuery,
+  useAddPlayerMutation,
+  updateLocalId,
+} from 'store/player';
 import { useGetTeamListQuery, updateTeam } from 'store/team';
 
 import { useGenerateAndStoreSessionId } from 'hooks/useGenerateAndStoreSessionId';
@@ -76,7 +81,9 @@ export const Layout: FC = () => {
   }, [isExistLocalId, getPlayerSuccess]);
 
   // 既存のチーム情報取得
-  const {} = useGetTeamListQuery();
+  const { isSuccess: getTeamArticleSuccess } = useGetTeamArticleQuery(selectedTeam || '', {
+    skip: !selectedTeam,
+  });
 
   // ローカルストレージへ既存のチームが保存されているか
   const [isExistSelectedTeam, setIsExistSelectedTeam] = useState<string>('');

--- a/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.module.scss
+++ b/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.module.scss
@@ -1,0 +1,101 @@
+@use "style/_variable" as *;
+
+.header {
+  position: sticky;
+  top: 0;
+  right: 0;
+  left: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: rem(48);
+  background: #fffe;
+}
+
+.title {
+  padding: 0 rem(6);
+}
+
+// メニュー開閉ボタン
+.opener {
+  @include rect(rem(48));
+
+  position: fixed;
+  top: 0;
+  right: 0;
+  display: grid;
+  place-items: center;
+  padding: 0;
+  font-size: rem(24);
+  cursor: pointer;
+  background: none;
+  border: none;
+  outline: none;
+  appearance: none;
+}
+
+// メニューボタン
+.menuButton {
+  display: flex;
+  gap: rem(12);
+  align-items: center;
+  padding: rem(6) rem(6);
+  background: none;
+  border: none;
+  outline: none;
+  appearance: none;
+}
+
+.menuIcon {
+  @include rect(rem(24));
+
+  display: grid;
+  place-items: center;
+  font-size: rem(24);
+  cursor: pointer;
+  background: none;
+  border: none;
+  outline: none;
+  appearance: none;
+}
+
+// パネル
+.panel {
+    position: fixed;
+    top: rem(48);
+    right: 0;
+    width: 100%;
+    padding: rem(24);
+    background: white;
+
+  // headless UI Transition
+  &.enter {
+    transition: opacity $t_enter, transform $t_enter;
+  }
+
+  &.leave {
+    transition: opacity $t_leave, transform $t_leave;
+  }
+
+  &.enterFrom,
+  &.leaveTo {
+    opacity: 0;
+    transform: translateY(-.5em);
+  }
+
+  &.enterTo,
+  &.leaveFrom {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+// 背景
+.overlay {
+  @include fit;
+
+  position: fixed;
+  top: rem(48);
+  background: #0006;
+}

--- a/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.module.scss
+++ b/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.module.scss
@@ -1,7 +1,7 @@
 @use "style/_variable" as *;
 
 .header {
-  position: sticky;
+  position: fixed;
   top: 0;
   right: 0;
   left: 0;
@@ -28,11 +28,12 @@
   place-items: center;
   padding: 0;
   font-size: rem(24);
+  color: currentColor;
   cursor: pointer;
   background: none;
   border: none;
   outline: none;
-  appearance: none;
+  appearance: none
 }
 
 // メニューボタン
@@ -41,6 +42,7 @@
   gap: rem(12);
   align-items: center;
   padding: rem(6) rem(6);
+  color: currentColor;
   background: none;
   border: none;
   outline: none;

--- a/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.stories.tsx
+++ b/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.stories.tsx
@@ -1,0 +1,15 @@
+import { action } from '@storybook/addon-actions';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { LayoutHeader } from './LayoutHeader';
+
+export default {
+  title: 'LayoutHeader',
+  component: LayoutHeader,
+  args: {
+    handleClick: action(''),
+  },
+} as ComponentMeta<typeof LayoutHeader>;
+export const Basic: ComponentStory<typeof LayoutHeader> = args => (
+  <LayoutHeader {...args}></LayoutHeader>
+);

--- a/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.tsx
+++ b/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.tsx
@@ -1,0 +1,57 @@
+import { FC, Fragment, useEffect, useRef, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { Popover, Transition } from '@headlessui/react';
+import { MdMenu, MdClose, MdLogout } from 'react-icons/md';
+
+import styles from './LayoutHeader.module.scss';
+
+type LayoutHeaderProps = {
+  addClass?: string[];
+  handleClick?: () => void;
+};
+
+export const LayoutHeader: FC<LayoutHeaderProps> = ({ addClass = [], handleClick }) => {
+  const navigate = useNavigate();
+  return (
+    <div className={[styles.header, ...addClass].join(' ')}>
+      <div className={styles.title}>⚡️ TeamVolt</div>
+      {handleClick && <button onClick={handleClick}>click</button>}
+      <Popover>
+        {({ open, close }) => (
+          <div className={styles.popover}>
+            <Popover.Button className={styles.opener}>
+              {open ? <MdClose /> : <MdMenu />}
+            </Popover.Button>
+            <Popover.Overlay className={styles.overlay} />
+            <Transition
+              as={Fragment}
+              show={open}
+              enter={styles.enter}
+              enterFrom={styles.enterFrom}
+              enterTo={styles.enterTo}
+              leave={styles.leave}
+              leaveFrom={styles.leaveFrom}
+              leaveTo={styles.leaveTo}
+            >
+              <Popover.Panel className={styles.panel}>
+                <button
+                  className={styles.menuButton}
+                  type="button"
+                  onClick={() => {
+                    close();
+                    navigate('/');
+                  }}
+                >
+                  <MdLogout className={styles.menuIcon} />
+                  Leave the mission
+                </button>
+              </Popover.Panel>
+            </Transition>
+          </div>
+        )}
+      </Popover>
+    </div>
+  );
+};

--- a/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.tsx
+++ b/src/components/layout/Layout/components/LayoutHeader/LayoutHeader.tsx
@@ -1,4 +1,4 @@
-import { FC, Fragment, useEffect, useRef, useState } from 'react';
+import { FC, Fragment } from 'react';
 
 import { useNavigate } from 'react-router-dom';
 

--- a/src/components/layout/Layout/components/LayoutHeader/index.ts
+++ b/src/components/layout/Layout/components/LayoutHeader/index.ts
@@ -1,0 +1,1 @@
+export { LayoutHeader } from './LayoutHeader';

--- a/src/components/pages/EnergyCharge/EnergyCharge.module.scss
+++ b/src/components/pages/EnergyCharge/EnergyCharge.module.scss
@@ -4,6 +4,7 @@
   display: grid;
   grid-template-rows: auto 1fr auto;
   height: 100%;
+  padding: rem(48) 0 0;
 
   * {
     user-select: none;

--- a/src/components/pages/EnergyCharge/EnergyCharge.tsx
+++ b/src/components/pages/EnergyCharge/EnergyCharge.tsx
@@ -22,8 +22,9 @@ export const EnergyCharge: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const { localId, myTeam, genEnergy } = useSelector((state: RootState) => state.player);
-  const { selectedTeam } = useSelector((state: RootState) => state.team);
+  const { localId, selectedTeam, myTeam, genEnergy } = useSelector(
+    (state: RootState) => state.player
+  );
 
   // 役職
   const job = useMemo(() => {

--- a/src/components/pages/EnergyCharge/EnergyCharge.tsx
+++ b/src/components/pages/EnergyCharge/EnergyCharge.tsx
@@ -137,6 +137,7 @@ export const EnergyCharge: FC = () => {
               handleClick={() => {
                 navigate('/target-lead');
               }}
+              disabled={totalChargeUnits > 0}
             >
               Start Rescue
             </Button>

--- a/src/components/pages/EnergyCharge/EnergyCharge.tsx
+++ b/src/components/pages/EnergyCharge/EnergyCharge.tsx
@@ -137,7 +137,7 @@ export const EnergyCharge: FC = () => {
               handleClick={() => {
                 navigate('/target-lead');
               }}
-              disabled={totalChargeUnits > 0}
+              disabled={totalChargeUnits < 1}
             >
               Start Rescue
             </Button>

--- a/src/components/pages/EnergyCharge/EnergyCharge.tsx
+++ b/src/components/pages/EnergyCharge/EnergyCharge.tsx
@@ -193,13 +193,6 @@ export const EnergyCharge: FC = () => {
             {currentTime >= limit && (
               <>
                 <Button handleClick={handleSubmit}>submit</Button>
-                <Button
-                  handleClick={() => {
-                    navigate('/');
-                  }}
-                >
-                  exit
-                </Button>
               </>
             )}
           </footer>

--- a/src/components/pages/EnergyCharge/EnergyCharge.tsx
+++ b/src/components/pages/EnergyCharge/EnergyCharge.tsx
@@ -6,8 +6,12 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { updateGenEnergy, resetEnergy } from 'store/player';
-import { useGetTeamArticleQuery, useAddChargeUnitsMutation } from 'store/team';
+import {
+  useGetTeamArticleQuery,
+  useAddChargeUnitsMutation,
+  updateGenEnergy,
+  resetEnergy,
+} from 'store/player';
 
 import styles from './EnergyCharge.module.scss';
 
@@ -18,13 +22,8 @@ export const EnergyCharge: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
 
-  const { localId, genEnergy } = useSelector((state: RootState) => state.player);
-  const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
-
-  // 所属チームの情報
-  const myTeam = useMemo(() => {
-    return teamList.find(team => team.id === selectedTeam);
-  }, [teamList, selectedTeam]);
+  const { localId, myTeam, genEnergy } = useSelector((state: RootState) => state.player);
+  const { selectedTeam } = useSelector((state: RootState) => state.team);
 
   // 役職
   const job = useMemo(() => {

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -6,16 +6,14 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useRemoveMemberMutation, useRemoveChallengerMutation } from 'store/player';
-import { escapeTeam } from 'store/team';
+import { escapeTeam, useRemoveMemberMutation, useRemoveChallengerMutation } from 'store/player';
 
 import styles from './Home.module.scss';
 
 export const Home: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { localId, myTeam } = useSelector((state: RootState) => state.player);
-  const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
+  const { localId, selectedTeam, myTeam } = useSelector((state: RootState) => state.player);
 
   // 代表者を削除する
   const [sendRemoveChallenger] = useRemoveChallengerMutation();

--- a/src/components/pages/Home/Home.tsx
+++ b/src/components/pages/Home/Home.tsx
@@ -6,20 +6,16 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useRemoveMemberMutation, useRemoveChallengerMutation, escapeTeam } from 'store/team';
+import { useRemoveMemberMutation, useRemoveChallengerMutation } from 'store/player';
+import { escapeTeam } from 'store/team';
 
 import styles from './Home.module.scss';
 
 export const Home: FC = () => {
   const navigate = useNavigate();
   const dispatch = useDispatch();
-  const { localId } = useSelector((state: RootState) => state.player);
+  const { localId, myTeam } = useSelector((state: RootState) => state.player);
   const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
-
-  // 所属チームの情報
-  const myTeam = useMemo(() => {
-    return teamList.find(team => team.id === selectedTeam);
-  }, [teamList, selectedTeam]);
 
   // 代表者を削除する
   const [sendRemoveChallenger] = useRemoveChallengerMutation();

--- a/src/components/pages/TargetLead/TargetLead.module.scss
+++ b/src/components/pages/TargetLead/TargetLead.module.scss
@@ -4,6 +4,7 @@
   display: grid;
   grid-template-rows: auto 1fr auto;
   height: 100%;
+  padding: rem(48) 0 0;
 }
 
 

--- a/src/components/pages/TargetLead/TargetLead.tsx
+++ b/src/components/pages/TargetLead/TargetLead.tsx
@@ -6,8 +6,11 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useGetTeamArticleQuery } from 'store/team';
-import { useUpdateUsedUnitsMutation, useUpdateCurrentPositionMutation } from 'store/team';
+import {
+  useGetTeamArticleQuery,
+  useUpdateUsedUnitsMutation,
+  useUpdateCurrentPositionMutation,
+} from 'store/player';
 
 import styles from './TargetLead.module.scss';
 
@@ -16,13 +19,8 @@ import { MissionMap } from './components/MissionMap';
 
 export const TargetLead: FC = () => {
   const navigate = useNavigate();
-  const { localId } = useSelector((state: RootState) => state.player);
-  const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
-
-  // 所属チームの情報
-  const myTeam = useMemo(() => {
-    return teamList.find(team => team.id === selectedTeam);
-  }, [teamList, selectedTeam]);
+  const { localId, myTeam } = useSelector((state: RootState) => state.player);
+  const { selectedTeam } = useSelector((state: RootState) => state.team);
 
   // 役職
   const job = useMemo(() => {

--- a/src/components/pages/TargetLead/TargetLead.tsx
+++ b/src/components/pages/TargetLead/TargetLead.tsx
@@ -19,8 +19,7 @@ import { MissionMap } from './components/MissionMap';
 
 export const TargetLead: FC = () => {
   const navigate = useNavigate();
-  const { localId, myTeam } = useSelector((state: RootState) => state.player);
-  const { selectedTeam } = useSelector((state: RootState) => state.team);
+  const { localId, selectedTeam, myTeam } = useSelector((state: RootState) => state.player);
 
   // 役職
   const job = useMemo(() => {

--- a/src/components/pages/TargetLead/TargetLead.tsx
+++ b/src/components/pages/TargetLead/TargetLead.tsx
@@ -168,33 +168,36 @@ export const TargetLead: FC = () => {
       </div>
 
       <footer className={styles.footer}>
-        {job === 'Rescuer' ? (
-          <>
-            {!isSearching ? (
-              <Button handleClick={handleBoost} disabled={isFailed || isComplete}>
-                Search for Rescues
-              </Button>
-            ) : (
-              <Button handleClick={handleCharge} disabled={isFailed || isComplete}>
-                Deliver Charge
-              </Button>
-            )}
-          </>
+        {!isFailed && !isComplete ? (
+          job === 'Rescuer' ? (
+            <>
+              {!isSearching ? (
+                <Button handleClick={handleBoost} disabled={isFailed || isComplete}>
+                  Search for Rescues
+                </Button>
+              ) : (
+                <Button handleClick={handleCharge} disabled={isFailed || isComplete}>
+                  Deliver Charge
+                </Button>
+              )}
+            </>
+          ) : (
+            <Button
+              handleClick={handleTeamProgressRequest}
+              disabled={getDrawResultLoading || getDrawResultFetching}
+            >
+              Check Mission Progress
+            </Button>
+          )
         ) : (
           <Button
-            handleClick={handleTeamProgressRequest}
-            disabled={getDrawResultLoading || getDrawResultFetching}
+            handleClick={() => {
+              navigate('/');
+            }}
           >
-            Check Mission Progress
+            Close Mission
           </Button>
         )}
-        <Button
-          handleClick={() => {
-            navigate('/');
-          }}
-        >
-          cancel
-        </Button>
       </footer>
     </article>
   );

--- a/src/components/pages/TargetLead/__snapshots__/TargetLead.test.tsx.snap
+++ b/src/components/pages/TargetLead/__snapshots__/TargetLead.test.tsx.snap
@@ -70,10 +70,9 @@ exports[`TargetLead TargetLeadのスナップショット 1`] = `
     >
       <button
         class="button --basic"
-        disabled=""
         type="button"
       >
-        Search for Rescues
+        Check Mission Progress
       </button>
       <button
         class="button --basic"

--- a/src/components/pages/TargetLead/components/MissionMap/MissionMap.module.scss
+++ b/src/components/pages/TargetLead/components/MissionMap/MissionMap.module.scss
@@ -2,8 +2,8 @@
 
 .missionMap {
   position: relative;
-  height: 100vmin;
-  margin: rem(24) 0;
+  height: 85vmin;
+  margin: rem(24) 0 0;
   background: radial-gradient(circle, rgb(0 0 0 / 50%), black);
 }
 
@@ -40,7 +40,6 @@
   display: grid;
   place-items: center;
   color: white;
-  border-radius: 50%;
 
   &::before {
     position: absolute;

--- a/src/components/pages/TeamUp/TeamUp.module.scss
+++ b/src/components/pages/TeamUp/TeamUp.module.scss
@@ -1,9 +1,10 @@
 @use "style/_variable" as *;
 
-.team {
+.article {
   display: grid;
   grid-template-rows: auto 1fr auto;
   height: 100%;
+  padding: rem(48) 0 0;
 }
 
 // ヘッダー

--- a/src/components/pages/TeamUp/TeamUp.tsx
+++ b/src/components/pages/TeamUp/TeamUp.tsx
@@ -21,6 +21,9 @@ export const TeamUp: FC = () => {
   const { localId } = useSelector((state: RootState) => state.player);
   const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
 
+  // 全チーム情報を取得
+  const { refetch: getTeamListRefetch } = useGetTeamListQuery();
+
   // チーム選択
   const handleSelectTeam = useCallback(
     (myTeamId: string) => {
@@ -94,6 +97,7 @@ export const TeamUp: FC = () => {
           <Button handleClick={joinTeam} disabled={entriesAddLoading || !selectedTeam || !localId}>
             join
           </Button>
+          <Button handleClick={getTeamListRefetch}>reload</Button>
           <Button
             handleClick={() => {
               navigate('/');

--- a/src/components/pages/TeamUp/TeamUp.tsx
+++ b/src/components/pages/TeamUp/TeamUp.tsx
@@ -6,8 +6,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useAddMemberMutation } from 'store/player';
-import { useGetTeamListQuery, useRemoveTeamMutation, updateTeam } from 'store/team';
+import { updateTeam, useAddMemberMutation } from 'store/player';
+import { useGetTeamListQuery, useRemoveTeamMutation } from 'store/team';
 
 import styles from './TeamUp.module.scss';
 
@@ -18,8 +18,8 @@ export const TeamUp: FC = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const { localId } = useSelector((state: RootState) => state.player);
-  const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
+  const { localId, selectedTeam } = useSelector((state: RootState) => state.player);
+  const { teamList } = useSelector((state: RootState) => state.team);
 
   // 全チーム情報を取得
   const { refetch: getTeamListRefetch } = useGetTeamListQuery();

--- a/src/components/pages/TeamUp/TeamUp.tsx
+++ b/src/components/pages/TeamUp/TeamUp.tsx
@@ -6,8 +6,8 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useGetTeamListQuery, useAddMemberMutation, updateTeam } from 'store/team';
-import { useRemoveTeamMutation } from 'store/team';
+import { useAddMemberMutation } from 'store/player';
+import { useGetTeamListQuery, useRemoveTeamMutation, updateTeam } from 'store/team';
 
 import styles from './TeamUp.module.scss';
 

--- a/src/components/pages/TeamUp/TeamUp.tsx
+++ b/src/components/pages/TeamUp/TeamUp.tsx
@@ -65,7 +65,7 @@ export const TeamUp: FC = () => {
 
   return (
     <>
-      <article className={styles.team}>
+      <article className={styles.article}>
         <header className={styles.header}>
           <h1>Pick Your Team</h1>
         </header>
@@ -98,13 +98,6 @@ export const TeamUp: FC = () => {
             join
           </Button>
           <Button handleClick={getTeamListRefetch}>reload</Button>
-          <Button
-            handleClick={() => {
-              navigate('/');
-            }}
-          >
-            cancel
-          </Button>
         </footer>
       </article>
     </>

--- a/src/components/pages/TeamUp/__snapshots__/TeamUp.test.tsx.snap
+++ b/src/components/pages/TeamUp/__snapshots__/TeamUp.test.tsx.snap
@@ -59,6 +59,12 @@ exports[`Team Teamのスナップショット 1`] = `
         class="button --basic"
         type="button"
       >
+        reload
+      </button>
+      <button
+        class="button --basic"
+        type="button"
+      >
         cancel
       </button>
     </footer>

--- a/src/components/pages/WaitingRoom/WaitingRoom.module.scss
+++ b/src/components/pages/WaitingRoom/WaitingRoom.module.scss
@@ -1,9 +1,10 @@
 @use "style/_variable" as *;
 
-.waitingRoom {
+.article {
   display: grid;
   grid-template-rows: auto 1fr auto;
   height: 100%;
+  padding: rem(48) 0 0;
 }
 
 // ヘッダー

--- a/src/components/pages/WaitingRoom/WaitingRoom.tsx
+++ b/src/components/pages/WaitingRoom/WaitingRoom.tsx
@@ -14,8 +14,7 @@ import { CurrentMembers } from './components/CurrentMembers/CurrentMembers';
 
 export const WaitingRoom: FC = () => {
   const navigate = useNavigate();
-  const { localId, myTeam } = useSelector((state: RootState) => state.player);
-  const { selectedTeam } = useSelector((state: RootState) => state.team);
+  const { localId, selectedTeam, myTeam } = useSelector((state: RootState) => state.player);
 
   // チーム情報の取得
   const {

--- a/src/components/pages/WaitingRoom/WaitingRoom.tsx
+++ b/src/components/pages/WaitingRoom/WaitingRoom.tsx
@@ -73,7 +73,7 @@ export const WaitingRoom: FC = () => {
 
   return myTeam ? (
     <>
-      <article className={styles.waitingRoom}>
+      <article className={styles.article}>
         <header className={styles.header}>
           <h1>{myTeam?.name}</h1>
         </header>
@@ -95,13 +95,6 @@ export const WaitingRoom: FC = () => {
           >
             reload
           </Button>
-          <Button
-            handleClick={() => {
-              navigate('/');
-            }}
-          >
-            cancel
-          </Button>
         </footer>
       </article>
     </>
@@ -119,13 +112,6 @@ export const WaitingRoom: FC = () => {
             }}
           >
             Team Up!
-          </Button>
-          <Button
-            handleClick={() => {
-              navigate('/');
-            }}
-          >
-            cancel
           </Button>
         </footer>
       </article>

--- a/src/components/pages/WaitingRoom/WaitingRoom.tsx
+++ b/src/components/pages/WaitingRoom/WaitingRoom.tsx
@@ -6,7 +6,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { Button } from 'components/parts/Button';
 import { RootState } from 'store';
-import { useGetTeamArticleQuery, useAddChallengerMutation } from 'store/team';
+import { useGetTeamArticleQuery, useAddChallengerMutation } from 'store/player';
 
 import styles from './WaitingRoom.module.scss';
 
@@ -14,13 +14,8 @@ import { CurrentMembers } from './components/CurrentMembers/CurrentMembers';
 
 export const WaitingRoom: FC = () => {
   const navigate = useNavigate();
-  const { localId } = useSelector((state: RootState) => state.player);
-  const { teamList, selectedTeam } = useSelector((state: RootState) => state.team);
-
-  // 所属チームの情報
-  const myTeam = useMemo(() => {
-    return teamList.find(team => team.id === selectedTeam);
-  }, [teamList, selectedTeam]);
+  const { localId, myTeam } = useSelector((state: RootState) => state.player);
+  const { selectedTeam } = useSelector((state: RootState) => state.team);
 
   // チーム情報の取得
   const {

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,12 +1,13 @@
 import { combineReducers, configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 
-import player, { playerGetApi, playerAddApi } from './player';
+import player, { playerGetApi, teamArticleGetApi, playerAddApi } from './player';
 import team, { teamGetApi, teamPostApi } from './team';
 
 const reducer = combineReducers({
   player,
   [playerGetApi.reducerPath]: playerGetApi.reducer,
   [playerAddApi.reducerPath]: playerAddApi.reducer,
+  [teamArticleGetApi.reducerPath]: teamArticleGetApi.reducer,
   team,
   [teamGetApi.reducerPath]: teamGetApi.reducer,
   [teamPostApi.reducerPath]: teamPostApi.reducer,
@@ -14,6 +15,7 @@ const reducer = combineReducers({
 
 const middleware = getDefaultMiddleware({ serializableCheck: false }).concat(
   playerGetApi.middleware,
+  teamArticleGetApi.middleware,
   playerAddApi.middleware,
   teamGetApi.middleware,
   teamPostApi.middleware

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,24 +1,26 @@
 import { combineReducers, configureStore, getDefaultMiddleware } from '@reduxjs/toolkit';
 
-import player, { playerGetApi, teamArticleGetApi, playerAddApi } from './player';
-import team, { teamGetApi, teamPostApi } from './team';
+import player, { playerGetApi, teamArticleGetApi, playerAddApi, teamPostApi } from './player';
+import team, { teamGetApi, teamListPostApi } from './team';
 
 const reducer = combineReducers({
   player,
   [playerGetApi.reducerPath]: playerGetApi.reducer,
   [playerAddApi.reducerPath]: playerAddApi.reducer,
   [teamArticleGetApi.reducerPath]: teamArticleGetApi.reducer,
+  [teamPostApi.reducerPath]: teamPostApi.reducer,
   team,
   [teamGetApi.reducerPath]: teamGetApi.reducer,
-  [teamPostApi.reducerPath]: teamPostApi.reducer,
+  [teamListPostApi.reducerPath]: teamListPostApi.reducer,
 });
 
 const middleware = getDefaultMiddleware({ serializableCheck: false }).concat(
   playerGetApi.middleware,
   teamArticleGetApi.middleware,
+  teamPostApi.middleware,
   playerAddApi.middleware,
   teamGetApi.middleware,
-  teamPostApi.middleware
+  teamListPostApi.middleware
 );
 
 export const store = configureStore({ reducer, middleware });

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -21,8 +21,9 @@ type State = {
   localId: string;
   player?: string;
   playerList: PlayerArticleData[];
-  genEnergy: number;
+  selectedTeam?: string;
   myTeam?: TeamArticleData;
+  genEnergy: number;
 };
 
 const initialState: State = {
@@ -298,6 +299,20 @@ const player = createSlice({
         localId: action.payload,
       };
     },
+    // 所属チーム更新
+    updateTeam: (state, action: PayloadAction<string>) => {
+      return {
+        ...state,
+        selectedTeam: action.payload,
+      };
+    },
+    // 所属チーム脱退
+    escapeTeam: state => {
+      return {
+        ...state,
+        selectedTeam: undefined,
+      };
+    },
     // 獲得エネルギーを更新
     updateGenEnergy: (state, action: PayloadAction<number>) => {
       return {
@@ -392,7 +407,8 @@ const player = createSlice({
 });
 
 // Action Creator
-export const { updateLocalId, updateGenEnergy, resetEnergy } = player.actions;
+export const { updateLocalId, updateTeam, escapeTeam, updateGenEnergy, resetEnergy } =
+  player.actions;
 
 // Reducer
 export default player.reducer;

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -8,7 +8,6 @@ import {
   arrayRemove,
   arrayUnion,
   addDoc,
-  deleteDoc,
   deleteField,
   collection,
   runTransaction,
@@ -336,6 +335,55 @@ const player = createSlice({
     // 成功: チーム情報取得
     builder.addMatcher(
       teamArticleGetApi.endpoints.getTeamArticle.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: メンバー追加
+    builder.addMatcher(
+      teamPostApi.endpoints.addMember.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: メンバー削除
+    builder.addMatcher(
+      teamPostApi.endpoints.removeMember.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: 代表者追加
+    builder.addMatcher(
+      teamPostApi.endpoints.addChallenger.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: 代表者削除
+    builder.addMatcher(
+      teamPostApi.endpoints.removeChallenger.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: 獲得バッテリー追加
+    builder.addMatcher(
+      teamPostApi.endpoints.addChargeUnits.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: 救出ミッション試行数更新
+    builder.addMatcher(
+      teamPostApi.endpoints.updateUsedUnits.matchFulfilled,
+      (state, action: PayloadAction<TeamArticleData>) => {
+        state.myTeam = action.payload;
+      }
+    );
+    // 成功: 救出ミッション進捗更新
+    builder.addMatcher(
+      teamPostApi.endpoints.updateCurrentPosition.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         state.myTeam = action.payload;
       }

--- a/src/store/player.ts
+++ b/src/store/player.ts
@@ -16,7 +16,7 @@ import {
 import { db } from 'firebaseDB';
 
 import type { PlayerArticleData } from 'types/player';
-import type { TeamArticleData } from 'types/team';
+import type { TeamArticleData, ChargeUnitsData } from 'types/team';
 
 type State = {
   localId: string;
@@ -93,6 +93,198 @@ export const playerAddApi = createApi({
   }),
 });
 export const { useAddPlayerMutation } = playerAddApi;
+
+// チーム情報の更新
+
+// チームメンバー編集
+type teamPostApiProps = {
+  operationType: string;
+  id?: string;
+  value?: string | number | ChargeUnitsData;
+};
+export const teamPostApi = createApi({
+  reducerPath: 'teamPostApi',
+  baseQuery: async ({ operationType, id, value }: teamPostApiProps) => {
+    if (operationType === 'add_member' && id) {
+      // メンバーを追加
+      const docRef = doc(db, 'team', id);
+      await updateDoc(docRef, {
+        member: arrayUnion(value),
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'remove_member' && id) {
+      const docRef = doc(db, 'team', id);
+      // メンバーを削除
+      await updateDoc(docRef, {
+        member: arrayRemove(value),
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'add_challenger' && id) {
+      const docRef = doc(db, 'team', id);
+      // 代表者を登録
+      await updateDoc(docRef, {
+        challenger: value,
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'remove_challenger' && id) {
+      const docRef = doc(db, 'team', id);
+      // 代表者を削除
+      await updateDoc(docRef, {
+        challenger: deleteField(),
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'add_charge_units' && id && value) {
+      // 獲得バッテリーを登録
+      const docRef = doc(db, 'team', id);
+      try {
+        await runTransaction(db, async transaction => {
+          const sfDoc = await transaction.get(docRef);
+          if (!sfDoc.exists()) {
+            // eslint-disable-next-line no-throw-literal
+            throw 'Document does not exist!';
+          }
+          const oldList = sfDoc.data().chargeUnits || [];
+          const newList = [
+            ...oldList.filter(
+              (item: ChargeUnitsData) =>
+                item.member !== (value as unknown as ChargeUnitsData).member
+            ),
+            value,
+          ];
+          transaction.update(docRef, { chargeUnits: newList });
+        });
+      } catch (e) {
+        console.log('Transaction failure:', e);
+      }
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'update_used_units' && id) {
+      const docRef = doc(db, 'team', id);
+      // 救出ミッション試行回数を登録
+      await updateDoc(docRef, {
+        usedUnits: value,
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else if (operationType === 'update_current_positions' && id) {
+      const docRef = doc(db, 'team', id);
+      // 救出ミッション進捗を登録
+      await updateDoc(docRef, {
+        currentPosition: value,
+      });
+      // レスポンスで返す情報を再取得
+      const docSnap = await getDoc(docRef);
+      if (docSnap.exists()) {
+        return { data: { id, ...docSnap.data() } };
+      } else {
+        return { error: 'No such document!' };
+      }
+    } else {
+      return { error: 'No such document!' };
+    }
+  },
+  endpoints: builder => ({
+    // メンバー追加
+    addMember: builder.mutation<TeamArticleData, { id: string; value: string }>({
+      query: ({ id, value }) => ({
+        operationType: 'add_member',
+        id,
+        value,
+      }),
+    }),
+    // メンバー削除
+    removeMember: builder.mutation<TeamArticleData, { id: string; value: string }>({
+      query: ({ id, value }) => ({
+        operationType: 'remove_member',
+        id,
+        value,
+      }),
+    }),
+    // 抽選結果追加
+    addChallenger: builder.mutation<TeamArticleData, { id: string; value: string }>({
+      query: ({ id, value }) => ({
+        operationType: 'add_challenger',
+        id,
+        value,
+      }),
+    }),
+    // 抽選結果追加
+    removeChallenger: builder.mutation<TeamArticleData, { id: string; value: string }>({
+      query: ({ id, value }) => ({
+        operationType: 'remove_challenger',
+        id,
+        value,
+      }),
+    }),
+    // 獲得バッテリー追加
+    addChargeUnits: builder.mutation<TeamArticleData, { id: string; value: ChargeUnitsData }>({
+      query: ({ id, value }) => ({
+        operationType: 'add_charge_units',
+        id,
+        value,
+      }),
+    }),
+    // 救出ミッション試行数を更新
+    updateUsedUnits: builder.mutation<TeamArticleData, { id: string; value: number }>({
+      query: ({ id, value }) => ({
+        operationType: 'update_used_units',
+        id,
+        value,
+      }),
+    }),
+    // 救出ミッション進捗を更新
+    updateCurrentPosition: builder.mutation<TeamArticleData, { id: string; value: number }>({
+      query: ({ id, value }) => ({
+        operationType: 'update_current_positions',
+        id,
+        value,
+      }),
+    }),
+  }),
+});
+export const {
+  useAddMemberMutation,
+  useRemoveMemberMutation,
+  useAddChallengerMutation,
+  useRemoveChallengerMutation,
+  useAddChargeUnitsMutation,
+  useUpdateUsedUnitsMutation,
+  useUpdateCurrentPositionMutation,
+} = teamPostApi;
 
 const player = createSlice({
   name: 'player',

--- a/src/store/team.ts
+++ b/src/store/team.ts
@@ -8,7 +8,6 @@ import type { ChargeUnitsData } from 'types/team';
 
 type State = {
   teamList: TeamArticleData[];
-  selectedTeam?: string;
 };
 
 const initialState: State = {
@@ -86,22 +85,7 @@ const team = createSlice({
 
   initialState,
 
-  reducers: {
-    // 所属チーム更新
-    updateTeam: (state, action: PayloadAction<string>) => {
-      return {
-        ...state,
-        selectedTeam: action.payload,
-      };
-    },
-    // 所属チーム脱退
-    escapeTeam: state => {
-      return {
-        ...state,
-        selectedTeam: undefined,
-      };
-    },
-  },
+  reducers: {},
 
   extraReducers: builder => {
     // 成功: チームリスト情報取得
@@ -137,7 +121,7 @@ const team = createSlice({
 });
 
 // Action Creator
-export const { updateTeam, escapeTeam } = team.actions;
+// export const {} = team.actions;
 
 // Reducer
 export default team.reducer;

--- a/src/store/team.ts
+++ b/src/store/team.ts
@@ -65,14 +65,14 @@ export const teamGetApi = createApi({
 export const { useGetTeamListQuery, useGetTeamArticleQuery } = teamGetApi;
 
 // チームメンバー編集
-type teamPostApiProps = {
+type teamListPostApiProps = {
   operationType: string;
   id?: string;
   value?: string | number | ChargeUnitsData;
 };
-export const teamPostApi = createApi({
-  reducerPath: 'teamPostApi',
-  baseQuery: async ({ operationType, id, value }: teamPostApiProps) => {
+export const teamListPostApi = createApi({
+  reducerPath: 'teamListPostApi',
+  baseQuery: async ({ operationType, id, value }: teamListPostApiProps) => {
     if (operationType === 'add_team') {
       // チームを追加
       const teamRef = collection(db, 'team');
@@ -280,7 +280,7 @@ export const {
   useAddChargeUnitsMutation,
   useUpdateUsedUnitsMutation,
   useUpdateCurrentPositionMutation,
-} = teamPostApi;
+} = teamListPostApi;
 
 const team = createSlice({
   name: 'team',
@@ -322,7 +322,7 @@ const team = createSlice({
     );
     // 成功: チーム追加
     builder.addMatcher(
-      teamPostApi.endpoints.addTeam.matchFulfilled,
+      teamListPostApi.endpoints.addTeam.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const result = { teamList: [...state.teamList, action.payload] };
         return {
@@ -333,7 +333,7 @@ const team = createSlice({
     );
     // 成功: チーム削除
     builder.addMatcher(
-      teamPostApi.endpoints.removeTeam.matchFulfilled,
+      teamListPostApi.endpoints.removeTeam.matchFulfilled,
       (state, action: PayloadAction<string>) => {
         const result = state.teamList.filter(team => team.id !== action.payload);
         return {
@@ -344,7 +344,7 @@ const team = createSlice({
     );
     // 成功: メンバー追加
     builder.addMatcher(
-      teamPostApi.endpoints.addMember.matchFulfilled,
+      teamListPostApi.endpoints.addMember.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -352,7 +352,7 @@ const team = createSlice({
     );
     // 成功: メンバー削除
     builder.addMatcher(
-      teamPostApi.endpoints.removeMember.matchFulfilled,
+      teamListPostApi.endpoints.removeMember.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -360,7 +360,7 @@ const team = createSlice({
     );
     // 成功: 代表者追加
     builder.addMatcher(
-      teamPostApi.endpoints.addChallenger.matchFulfilled,
+      teamListPostApi.endpoints.addChallenger.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -368,7 +368,7 @@ const team = createSlice({
     );
     // 成功: 代表者削除
     builder.addMatcher(
-      teamPostApi.endpoints.removeChallenger.matchFulfilled,
+      teamListPostApi.endpoints.removeChallenger.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -376,7 +376,7 @@ const team = createSlice({
     );
     // 成功: 獲得バッテリー追加
     builder.addMatcher(
-      teamPostApi.endpoints.addChargeUnits.matchFulfilled,
+      teamListPostApi.endpoints.addChargeUnits.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -384,7 +384,7 @@ const team = createSlice({
     );
     // 成功: 救出ミッション試行数更新
     builder.addMatcher(
-      teamPostApi.endpoints.updateUsedUnits.matchFulfilled,
+      teamListPostApi.endpoints.updateUsedUnits.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];
@@ -392,7 +392,7 @@ const team = createSlice({
     );
     // 成功: 救出ミッション進捗更新
     builder.addMatcher(
-      teamPostApi.endpoints.updateCurrentPosition.matchFulfilled,
+      teamListPostApi.endpoints.updateCurrentPosition.matchFulfilled,
       (state, action: PayloadAction<TeamArticleData>) => {
         const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
         state.teamList = [...externalTeamList, action.payload];

--- a/src/store/team.ts
+++ b/src/store/team.ts
@@ -1,18 +1,6 @@
 import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { createApi } from '@reduxjs/toolkit/query/react';
-import {
-  doc,
-  getDoc,
-  getDocs,
-  updateDoc,
-  arrayRemove,
-  arrayUnion,
-  addDoc,
-  deleteDoc,
-  deleteField,
-  collection,
-  runTransaction,
-} from 'firebase/firestore';
+import { doc, getDocs, addDoc, deleteDoc, collection } from 'firebase/firestore';
 import { db } from 'firebaseDB';
 import { TeamArticleData } from 'types/team';
 
@@ -33,38 +21,23 @@ export const teamGetApi = createApi({
   reducerPath: 'teamGetApi',
   baseQuery: async ({ id }: { id?: string }) => {
     // 全データ
-    if (!id) {
-      const teamRef = collection(db, 'team');
-      const teamSnapshot = await getDocs(teamRef);
-      const result = teamSnapshot.docs.map(doc => {
-        return { id: doc.id, ...doc.data() };
-      });
-      return { data: result };
-    } else {
-      // 特定のデータ
-      const docRef = doc(db, 'team', id);
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    }
+    const teamRef = collection(db, 'team');
+    const teamSnapshot = await getDocs(teamRef);
+    const result = teamSnapshot.docs.map(doc => {
+      return { id: doc.id, ...doc.data() };
+    });
+    return { data: result };
   },
   endpoints: builder => ({
     // チーム情報取得
     getTeamList: builder.query<TeamArticleData[], void>({
       query: () => ({}),
     }),
-    // チーム情報取得
-    getTeamArticle: builder.query<TeamArticleData, string>({
-      query: id => ({ id }),
-    }),
   }),
 });
-export const { useGetTeamListQuery, useGetTeamArticleQuery } = teamGetApi;
+export const { useGetTeamListQuery } = teamGetApi;
 
-// チームメンバー編集
+// チーム編集
 type teamListPostApiProps = {
   operationType: string;
   id?: string;
@@ -85,114 +58,6 @@ export const teamListPostApi = createApi({
       // チームを削除
       await deleteDoc(doc(db, 'team', id));
       return { data: id };
-    } else if (operationType === 'add_member' && id) {
-      // メンバーを追加
-      const docRef = doc(db, 'team', id);
-      await updateDoc(docRef, {
-        member: arrayUnion(value),
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'remove_member' && id) {
-      const docRef = doc(db, 'team', id);
-      // メンバーを削除
-      await updateDoc(docRef, {
-        member: arrayRemove(value),
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'add_challenger' && id) {
-      const docRef = doc(db, 'team', id);
-      // 代表者を登録
-      await updateDoc(docRef, {
-        challenger: value,
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'remove_challenger' && id) {
-      const docRef = doc(db, 'team', id);
-      // 代表者を削除
-      await updateDoc(docRef, {
-        challenger: deleteField(),
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'add_charge_units' && id && value) {
-      // 獲得バッテリーを登録
-      const docRef = doc(db, 'team', id);
-      try {
-        await runTransaction(db, async transaction => {
-          const sfDoc = await transaction.get(docRef);
-          if (!sfDoc.exists()) {
-            // eslint-disable-next-line no-throw-literal
-            throw 'Document does not exist!';
-          }
-          const oldList = sfDoc.data().chargeUnits || [];
-          const newList = [
-            ...oldList.filter(
-              (item: ChargeUnitsData) =>
-                item.member !== (value as unknown as ChargeUnitsData).member
-            ),
-            value,
-          ];
-          transaction.update(docRef, { chargeUnits: newList });
-        });
-      } catch (e) {
-        console.log('Transaction failure:', e);
-      }
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'update_used_units' && id) {
-      const docRef = doc(db, 'team', id);
-      // 救出ミッション試行回数を登録
-      await updateDoc(docRef, {
-        usedUnits: value,
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
-    } else if (operationType === 'update_current_positions' && id) {
-      const docRef = doc(db, 'team', id);
-      // 救出ミッション進捗を登録
-      await updateDoc(docRef, {
-        currentPosition: value,
-      });
-      // レスポンスで返す情報を再取得
-      const docSnap = await getDoc(docRef);
-      if (docSnap.exists()) {
-        return { data: { id, ...docSnap.data() } };
-      } else {
-        return { error: 'No such document!' };
-      }
     } else {
       return { error: 'No such document!' };
     }
@@ -212,75 +77,9 @@ export const teamListPostApi = createApi({
         id,
       }),
     }),
-    // メンバー追加
-    addMember: builder.mutation<TeamArticleData, { id: string; value: string }>({
-      query: ({ id, value }) => ({
-        operationType: 'add_member',
-        id,
-        value,
-      }),
-    }),
-    // メンバー削除
-    removeMember: builder.mutation<TeamArticleData, { id: string; value: string }>({
-      query: ({ id, value }) => ({
-        operationType: 'remove_member',
-        id,
-        value,
-      }),
-    }),
-    // 抽選結果追加
-    addChallenger: builder.mutation<TeamArticleData, { id: string; value: string }>({
-      query: ({ id, value }) => ({
-        operationType: 'add_challenger',
-        id,
-        value,
-      }),
-    }),
-    // 抽選結果追加
-    removeChallenger: builder.mutation<TeamArticleData, { id: string; value: string }>({
-      query: ({ id, value }) => ({
-        operationType: 'remove_challenger',
-        id,
-        value,
-      }),
-    }),
-    // 獲得バッテリー追加
-    addChargeUnits: builder.mutation<TeamArticleData, { id: string; value: ChargeUnitsData }>({
-      query: ({ id, value }) => ({
-        operationType: 'add_charge_units',
-        id,
-        value,
-      }),
-    }),
-    // 救出ミッション試行数を更新
-    updateUsedUnits: builder.mutation<TeamArticleData, { id: string; value: number }>({
-      query: ({ id, value }) => ({
-        operationType: 'update_used_units',
-        id,
-        value,
-      }),
-    }),
-    // 救出ミッション進捗を更新
-    updateCurrentPosition: builder.mutation<TeamArticleData, { id: string; value: number }>({
-      query: ({ id, value }) => ({
-        operationType: 'update_current_positions',
-        id,
-        value,
-      }),
-    }),
   }),
 });
-export const {
-  useAddTeamMutation,
-  useRemoveTeamMutation,
-  useAddMemberMutation,
-  useRemoveMemberMutation,
-  useAddChallengerMutation,
-  useRemoveChallengerMutation,
-  useAddChargeUnitsMutation,
-  useUpdateUsedUnitsMutation,
-  useUpdateCurrentPositionMutation,
-} = teamListPostApi;
+export const { useAddTeamMutation, useRemoveTeamMutation } = teamListPostApi;
 
 const team = createSlice({
   name: 'team',
@@ -312,14 +111,6 @@ const team = createSlice({
         state.teamList = action.payload;
       }
     );
-    // 成功: チーム情報取得
-    builder.addMatcher(
-      teamGetApi.endpoints.getTeamArticle.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
     // 成功: チーム追加
     builder.addMatcher(
       teamListPostApi.endpoints.addTeam.matchFulfilled,
@@ -340,62 +131,6 @@ const team = createSlice({
           teamList: result,
           selectedTeam: undefined,
         };
-      }
-    );
-    // 成功: メンバー追加
-    builder.addMatcher(
-      teamListPostApi.endpoints.addMember.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: メンバー削除
-    builder.addMatcher(
-      teamListPostApi.endpoints.removeMember.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: 代表者追加
-    builder.addMatcher(
-      teamListPostApi.endpoints.addChallenger.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: 代表者削除
-    builder.addMatcher(
-      teamListPostApi.endpoints.removeChallenger.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: 獲得バッテリー追加
-    builder.addMatcher(
-      teamListPostApi.endpoints.addChargeUnits.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: 救出ミッション試行数更新
-    builder.addMatcher(
-      teamListPostApi.endpoints.updateUsedUnits.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
-      }
-    );
-    // 成功: 救出ミッション進捗更新
-    builder.addMatcher(
-      teamListPostApi.endpoints.updateCurrentPosition.matchFulfilled,
-      (state, action: PayloadAction<TeamArticleData>) => {
-        const externalTeamList = state.teamList.filter(team => team.id !== action.payload.id);
-        state.teamList = [...externalTeamList, action.payload];
       }
     );
   },

--- a/src/style/_variable/_transition.scss
+++ b/src/style/_variable/_transition.scss
@@ -1,1 +1,5 @@
 $t_ease: 250ms ease;
+$t_duration: 250;
+$t_ease: #{$t_duration * 1ms} ease;
+$t_enter: #{($t_duration * 1.5) * 1ms} ease-out;
+$t_leave: #{$t_duration * 1ms} ease-in;

--- a/src/style/index.scss
+++ b/src/style/index.scss
@@ -4,6 +4,10 @@
 // GoogleFonts
 // @import url('https://fonts.googleapis.com/css2?family=M+PLUS+Rounded+1c:wght@500;800&family=Montserrat:wght@800&display=swap');
 
+html {
+  height: 100%;
+}
+
 body {
   height: 100dvh;
   min-height: 100%;


### PR DESCRIPTION
 - 誤ってタップしやすいボタンレイアウトを修正
- ヘッダーメニューを設け、離脱選択肢を開閉メニュー内に移動
- 状態管理をチームデータ単位に変更