### PR TITLE
プレイログの記録

### DIFF
--- a/src/components/pages/TargetLead/TargetLead.tsx
+++ b/src/components/pages/TargetLead/TargetLead.tsx
@@ -19,6 +19,7 @@ import { TeamArticleData } from 'types/team';
 import styles from './TargetLead.module.scss';
 
 import { BoostChallenge } from './components/BoostChallenge';
+import { ConfirmClose } from './components/ConfirmClose';
 import { MissionMap } from './components/MissionMap';
 
 export const TargetLead: FC = () => {
@@ -162,16 +163,16 @@ export const TargetLead: FC = () => {
     }
   }, [job, isComplete, isFailed, myTeam, addLogSuccess, addLogLoading, sendAddLog]);
 
+  // ミッション終了確認ダイアログ
+  const [confirmDelete, setConfirmDelete] = useState(false);
+
   // ミッション終了
   const [sendCloseMission] = useCloseMissionMutation();
 
   // ミッション結果をリセット
   const handleCloseMission = useCallback(() => {
-    if (selectedTeam && job === 'Rescuer') {
-      window.confirm(
-        'ミッションを閉じると、まだ結果を確認していないチームの仲間は結果を見られなくなります。全員が結果を確認できていたら、OKで閉じてください。'
-      ) && sendCloseMission(selectedTeam);
-    } else navigate('/team-up');
+    if (selectedTeam && job === 'Rescuer') setConfirmDelete(true);
+    else navigate('/team-up');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTeam]);
 
@@ -238,6 +239,17 @@ export const TargetLead: FC = () => {
           </Button>
         )}
       </div>
+      <ConfirmClose
+        isOpen={confirmDelete}
+        handleCancel={() => {
+          setConfirmDelete(false);
+        }}
+        handleAccept={() => {
+          selectedTeam && sendCloseMission(selectedTeam);
+          setConfirmDelete(false);
+          navigate('/team-up');
+        }}
+      />
     </div>
   );
 };

--- a/src/components/pages/TargetLead/TargetLead.tsx
+++ b/src/components/pages/TargetLead/TargetLead.tsx
@@ -1,4 +1,4 @@
-import { FC, useMemo, useState, useCallback } from 'react';
+import { FC, useMemo, useState, useCallback, useEffect } from 'react';
 
 import { useSelector } from 'react-redux';
 
@@ -13,6 +13,8 @@ import {
   useUpdateCurrentPositionMutation,
   useCloseMissionMutation,
 } from 'store/player';
+import { useAddLogMutation } from 'store/team';
+import { TeamArticleData } from 'types/team';
 
 import styles from './TargetLead.module.scss';
 
@@ -146,13 +148,30 @@ export const TargetLead: FC = () => {
     getDrawResultRefetch();
   }, [getDrawResultRefetch]);
 
+  // プレイ結果をログに追加
+  const [sendAddLog, { isSuccess: addLogSuccess, isLoading: addLogLoading }] = useAddLogMutation();
+
+  // ミッション結果をログに追加
+  useEffect(() => {
+    if (job === 'Rescuer' && myTeam) {
+      if (!addLogSuccess && !addLogLoading) {
+        if (isComplete || isFailed) {
+          sendAddLog(myTeam as TeamArticleData);
+        }
+      }
+    }
+  }, [job, isComplete, isFailed, myTeam, addLogSuccess, addLogLoading, sendAddLog]);
+
   // ミッション終了
   const [sendCloseMission] = useCloseMissionMutation();
 
   // ミッション結果をリセット
   const handleCloseMission = useCallback(() => {
-    if (selectedTeam) sendCloseMission(selectedTeam);
-    navigate('/team-up');
+    if (selectedTeam && job === 'Rescuer') {
+      window.confirm(
+        'ミッションを閉じると、まだ結果を確認していないチームの仲間は結果を見られなくなります。全員が結果を確認できていたら、OKで閉じてください。'
+      ) && sendCloseMission(selectedTeam);
+    } else navigate('/team-up');
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectedTeam]);
 
@@ -214,7 +233,9 @@ export const TargetLead: FC = () => {
             </>
           )
         ) : (
-          <Button handleClick={handleCloseMission}>このミッションを閉じる</Button>
+          <Button handleClick={handleCloseMission} disabled={addLogLoading}>
+            このミッションを閉じる
+          </Button>
         )}
       </div>
     </div>

--- a/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.module.scss
+++ b/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.module.scss
@@ -1,0 +1,100 @@
+@use "style/_variable" as *;
+
+.dialog {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 10;
+  display: grid;
+  place-items: center;
+  padding: rem(24);
+  background: #0006;
+}
+
+.dialogOverlay {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  background: #0006;
+
+  // headless UI Transition
+  &.enter {
+    transition: opacity #{($t_duration * 0.5) * 1ms} ease-out;
+  }
+
+  &.leave {
+    transition: opacity #{($t_duration * 1.5) * 1ms} ease-in;
+  }
+
+  &.enterFrom,
+  &.leaveTo {
+    opacity: 0;
+  }
+
+  &.enterTo,
+  &.leaveFrom {
+    opacity: 1;
+  }
+}
+
+.dialogPanel {
+  position: relative;
+  bottom: rem(24);
+  z-index: 10;
+  padding: rem(12);
+  margin: auto;
+  background: white;
+
+  // headless UI Transition
+  &.enter {
+    transition: opacity $t_enter, transform $t_enter;
+  }
+
+  &.leave {
+    transition: opacity $t_leave, transform $t_leave;
+  }
+
+  &.enterFrom,
+  &.leaveTo {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+
+  &.enterTo,
+  &.leaveFrom {
+    opacity: 1;
+    transform: scale(1);
+  }
+}
+
+.dialogTitle {
+  margin: rem(12);
+  font-size: rem(18);
+}
+
+.dialogDescription {
+  margin: rem(12);
+}
+
+.dialogFooter {
+  display: flex;
+  gap: rem(24);
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.dialogFooterButton {
+  padding: 0.5em 1em;
+}
+
+.dialogCancel {
+  padding: 0.5em 1em;
+  color: currentColor;
+  background-color: transparent;
+  border: none;
+  appearance: none;
+}

--- a/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.stories.tsx
+++ b/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.stories.tsx
@@ -1,0 +1,17 @@
+import { action } from '@storybook/addon-actions';
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+
+import { ConfirmClose } from './ConfirmClose';
+
+export default {
+  title: 'ConfirmClose',
+  component: ConfirmClose,
+  args: {
+    isOpen: true,
+    handleCancel: action('cancel'),
+    handleAccept: action('accept'),
+  },
+} as ComponentMeta<typeof ConfirmClose>;
+export const Basic: ComponentStory<typeof ConfirmClose> = args => (
+  <ConfirmClose {...args}></ConfirmClose>
+);

--- a/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.tsx
+++ b/src/components/pages/TargetLead/components/ConfirmClose/ConfirmClose.tsx
@@ -1,0 +1,67 @@
+import { FC, Fragment } from 'react';
+
+import { Dialog, Transition } from '@headlessui/react';
+import { Button } from 'components/parts/Button';
+
+import styles from './ConfirmClose.module.scss';
+
+type ConfirmCloseProps = {
+  isOpen: boolean;
+  addClass?: string[];
+  handleCancel: () => void;
+  handleAccept: () => void;
+  afterLeave?: () => void;
+};
+
+export const ConfirmClose: FC<ConfirmCloseProps> = ({
+  isOpen,
+  addClass = [],
+  handleCancel,
+  handleAccept,
+  afterLeave,
+}) => {
+  return (
+    <Transition show={isOpen} as={Fragment}>
+      <Dialog onClose={handleCancel} className={[styles.dialog, ...addClass].join(' ')}>
+        <Transition.Child
+          as={Fragment}
+          enter={styles.enter}
+          enterFrom={styles.enterFrom}
+          enterTo={styles.enterTo}
+          leave={styles.leave}
+          leaveFrom={styles.leaveFrom}
+          leaveTo={styles.leaveTo}
+        >
+          <Dialog.Overlay className={styles.dialogOverlay} />
+        </Transition.Child>
+        <Transition.Child
+          as={Fragment}
+          enter={styles.enter}
+          enterFrom={styles.enterFrom}
+          enterTo={styles.enterTo}
+          leave={styles.leave}
+          leaveFrom={styles.leaveFrom}
+          leaveTo={styles.leaveTo}
+          afterLeave={afterLeave}
+        >
+          <Dialog.Panel className={styles.dialogPanel}>
+            <Dialog.Title className={styles.dialogTitle}>ミッション終了</Dialog.Title>
+            <Dialog.Description className={styles.dialogDescription}>
+              ミッションを閉じると、まだ結果を確認していないチームの仲間は結果を見られなくなります。
+              <br />
+              全員が結果を確認できていたら、OKで閉じてください。
+            </Dialog.Description>
+            <div className={styles.dialogFooter}>
+              <button type="button" className={styles.dialogCancel} onClick={handleCancel}>
+                キャンセル
+              </button>
+              <Button handleClick={handleAccept} addClass={[styles.dialogFooterButton]}>
+                OK
+              </Button>
+            </div>
+          </Dialog.Panel>
+        </Transition.Child>
+      </Dialog>
+    </Transition>
+  );
+};

--- a/src/components/pages/TargetLead/components/ConfirmClose/index.ts
+++ b/src/components/pages/TargetLead/components/ConfirmClose/index.ts
@@ -1,0 +1,1 @@
+export { ConfirmClose } from './ConfirmClose';

--- a/src/store/team.ts
+++ b/src/store/team.ts
@@ -4,14 +4,14 @@ import { doc, getDocs, addDoc, deleteDoc, collection } from 'firebase/firestore'
 import { db } from 'firebaseDB';
 import { TeamArticleData } from 'types/team';
 
-import type { ChargeUnitsData } from 'types/team';
-
 type State = {
   teamList: TeamArticleData[];
+  logList?: TeamArticleData[];
 };
 
 const initialState: State = {
   teamList: [],
+  logList: [],
 };
 
 // RTK Queryの設定
@@ -40,7 +40,7 @@ export const { useGetTeamListQuery } = teamGetApi;
 type teamListPostApiProps = {
   operationType: string;
   id?: string;
-  value?: string | number | ChargeUnitsData;
+  value?: string | number | TeamArticleData;
 };
 export const teamListPostApi = createApi({
   reducerPath: 'teamListPostApi',
@@ -57,6 +57,11 @@ export const teamListPostApi = createApi({
       // チームを削除
       await deleteDoc(doc(db, 'team', id));
       return { data: id };
+    } else if (operationType === 'add_log' && value) {
+      // プレイログを追加
+      const logRef = collection(db, 'log');
+      await addDoc(logRef, value as TeamArticleData);
+      return { data: null };
     } else {
       return { error: 'No such document!' };
     }
@@ -76,9 +81,16 @@ export const teamListPostApi = createApi({
         id,
       }),
     }),
+    // プレイログを追加
+    addLog: builder.mutation<void, TeamArticleData>({
+      query: value => ({
+        operationType: 'add_log',
+        value,
+      }),
+    }),
   }),
 });
-export const { useAddTeamMutation, useRemoveTeamMutation } = teamListPostApi;
+export const { useAddTeamMutation, useRemoveTeamMutation, useAddLogMutation } = teamListPostApi;
 
 const team = createSlice({
   name: 'team',


### PR DESCRIPTION
- 連打の誤動作で全員が確認する前にログが消えやすくなっているUIをカイゼン
- 削除は救助係に限定
- 成功失敗の結果が出た段階でログをDBへ残す
- ミッション情報を消去する前に確認ダイアログをはさむ